### PR TITLE
resolve"Detected code that uses str for device registry entry_type" error

### DIFF
--- a/custom_components/openhab/entity.py
+++ b/custom_components/openhab/entity.py
@@ -5,6 +5,8 @@ from typing import Any, List
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType
+
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from openhab import items
 
@@ -71,7 +73,7 @@ class OpenHABEntity(CoordinatorEntity):
             model=version,
             manufacturer=NAME,
             configuration_url=self._base_url,
-            entry_type="service",
+            entry_type=DeviceEntryType.SERVICE,
         )
 
     @property


### PR DESCRIPTION
This solution appears to resolve the error message found in the GitHub issue link https://github.com/kubawolanin/ha-openhab/issues/23. However, the separate issue of "openhab entities only being refreshed when ha-openhab is refreshed" remains unresolved with this pull request.